### PR TITLE
Fix accessing uninitialized object problem

### DIFF
--- a/sdk/src/ws.c
+++ b/sdk/src/ws.c
@@ -427,10 +427,6 @@ void dslink_handshake_handle_ws(DSLink *link, link_callback on_requester_ready_c
         uv_timer_start(ping, ping_handler, 0, 30000);
     }
 
-    if (on_requester_ready_cb) {
-        on_requester_ready_cb(link);
-    }
-
 #ifdef DSLINK_WS_SEND_THREADED
     link->closingSendThread = 0;
     uv_sem_init(&link->ws_send_sem,0);
@@ -439,6 +435,10 @@ void dslink_handshake_handle_ws(DSLink *link, link_callback on_requester_ready_c
     uv_thread_create(&send_ws_thread_id, dslink_send_ws_thread, link);
 #endif
 
+    if (on_requester_ready_cb) {
+        on_requester_ready_cb(link);
+    }
+    
     uv_run(&link->loop, UV_RUN_DEFAULT);
 
     uv_timer_stop(ping);


### PR DESCRIPTION
When `DSLINK_WS_SEND_THREADED` defind, `dslink_handshake_handle_ws()` function calls `on_requester_ready_cb` callback without initialization of DSLink.ws_send_sem, DSLink.ws_queue_sem object.

It's easy to make mistake accessing uninitialized DSLink.ws_send_sem, DSLink.ws_queue_sem in `on_requester_ready_cb` callback ( Actually `example/requester` sample did it).

This commit make `on_requester_ready_cb` called after `DSLink.ws_send_sem` initialization.